### PR TITLE
fix re flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,6 @@ Added test.
 1. Updated `_parse_args_in_correct_type()` logic to exclude parsing the value of `indent` key when defining style using a dictionary. See https://github.com/largecats/sparksql-formatter/issues/72.
 2. Added test for setting indent style via dictionary.
 3. Updated tests to use unittest library.
+
+## 2024-11-06
+1. Updated `Tokenizer.BLOCK_COMMENT_REGEX` from `u'(\/\*(?s).*?\*\/)'` to `u'(?s:(\/\*.*?\*\/))'` to avoid "re.error: global flags not at the start of the expression at position 5" error. See https://github.com/largecats/sparksql-formatter/issues/74.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='sparksqlformatter',
-    version='0.1.12',
+    version='0.1.13',
     author='largecats',
     author_email='linfanxiaolinda@outlook.com',
     description=

--- a/sparksqlformatter/src/tokenizer.py
+++ b/sparksqlformatter/src/tokenizer.py
@@ -65,7 +65,7 @@ class Tokenizer:
         self.NUMBER_REGEX = r'^((-\s*)?[0-9]+(\.[0-9]+)?|0x[0-9a-fA-F]+|0b[01]+)\b'
         self.OPERATOR_REGEX = u'^([^\{\}]!=|<>|==|<=|>=|!=|!<|!>|\|\||::|->>|->|~~\*|~~|!~~\*|!~~|~\*|!~\*|!~|:=|.)'
 
-        self.BLOCK_COMMENT_REGEX = u'(\/\*(?s).*?\*\/)'  # (?s) is inline flag for re.DOTALL
+        self.BLOCK_COMMENT_REGEX = u'(?s:(\/\*.*?\*\/))'  # (?s:...) applies flag for re.DOTALL over ...
         self.LINE_COMMENT_REGEX = Tokenizer.create_line_comment_regex(style.lineCommentTypes)
 
         self.TOP_LEVEL_KEYWORD_REGEX = Tokenizer.create_keyword_regex(style.topLevelKeywords)


### PR DESCRIPTION
Updated `Tokenizer.BLOCK_COMMENT_REGEX` from `u'(\/\*(?s).*?\*\/)'` to `u'(?s:(\/\*.*?\*\/))'` to avoid "re.error: global flags not at the start of the expression at position 5" error to fix #74.